### PR TITLE
Warning cleanup

### DIFF
--- a/applications/iotree/pom.xml
+++ b/applications/iotree/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>iotree</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>Applications: IoTree (The IoT Christmas Tree)</name>
   <description>An example Application for the IoT Frankfurt meetup on 14.12.2017.</description>
 

--- a/applications/plclogger/pom.xml
+++ b/applications/plclogger/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plclogger</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>Applications: PLC Data Logger</name>
   <description>Application using Edgent and Elastic-Search to implement a PLC data logger.</description>
 

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -30,7 +30,6 @@
 
   <groupId>org.apache.plc4x.applications</groupId>
   <artifactId>applications</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Applications</name>

--- a/integrations/apache-brooklyn/pom.xml
+++ b/integrations/apache-brooklyn/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>apache-brooklyn</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Integrations: Apache Brooklyn</name>

--- a/integrations/apache-camel/pom.xml
+++ b/integrations/apache-camel/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>apache-camel</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>Integrations: Apache Camel</name>
   <description>Integration module for integrating PLC4X into Apache Camel.</description>
 

--- a/integrations/apache-edgent/pom.xml
+++ b/integrations/apache-edgent/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>apache-edgent</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>Integrations: Apache Edgent</name>
   <description>Integration module for integrating PLC4X into Apache Edgent.</description>
 

--- a/integrations/apache-edgent/src/main/java/org/apache/plc4x/edgent/PlcConnectionAdapter.java
+++ b/integrations/apache-edgent/src/main/java/org/apache/plc4x/edgent/PlcConnectionAdapter.java
@@ -184,13 +184,11 @@ public class PlcConnectionAdapter implements AutoCloseable{
     throw new IllegalArgumentException("Not a legal plc data type: "+cls.getSimpleName());
   }
 
-  @SuppressWarnings("unchecked")
   static <T> PlcWriteRequest newPlcWriteRequest(Address address, T value) {
     Class<?> cls = value.getClass();
     return new PlcWriteRequest(cls, address, value);
   }
 
-  @SuppressWarnings("unchecked")
   static <T> PlcReadRequest newPlcReadRequest(Class<T> datatype, Address address) {
       return new PlcReadRequest(datatype, address);
   }

--- a/integrations/apache-edgent/src/test/java/org/apache/plc4x/edgent/PlcConnectionAdapterTest.java
+++ b/integrations/apache-edgent/src/test/java/org/apache/plc4x/edgent/PlcConnectionAdapterTest.java
@@ -142,7 +142,6 @@ public class PlcConnectionAdapterTest {
   /*
    * Verify the adapter yields the appropriate PlcReadRequest for each type and that it works.
    */
-  @SuppressWarnings("unchecked")
   @Test
   @Tag("fast")
   public void testNewPlcReadRequest() throws Exception {
@@ -215,7 +214,6 @@ public class PlcConnectionAdapterTest {
   /*
    * Verify the adapter yields the appropriate PlcWriteRequest for each type and that it works.
    */
-  @SuppressWarnings("unchecked")
   @Test
   @Tag("fast")
   public void testNewPlcWriteRequest() throws Exception {
@@ -362,7 +360,6 @@ public class PlcConnectionAdapterTest {
   /*
    * test PlcConnectionAdapter.newConsumer(address)
    */
-  @SuppressWarnings("unchecked")
   @Test
   @Tag("fast")
   public void testNewConsumer1() throws Exception {
@@ -504,6 +501,7 @@ public class PlcConnectionAdapterTest {
   static <T> void checkConsumerJson(MockConnection connection, MockAddress address, Consumer<JsonObject> consumer, Object ... values) throws Exception {
     checkConsumerJson(0, connection, address, consumer, values);
   }
+  @SuppressWarnings("unchecked")
   private static <T> void checkConsumerJson(int writeFailureCountTrigger, MockConnection connection, MockAddress address, Consumer<JsonObject> consumer, Object ... values) throws Exception {
     if (writeFailureCountTrigger > 0)
       connection.setWriteException(writeFailureCountTrigger, "This is a mock write exception");
@@ -523,7 +521,6 @@ public class PlcConnectionAdapterTest {
       
       consumer.accept(jo);
       
-      @SuppressWarnings("unchecked")
       T writtenData = (T) connection.getDataValue(address);
       if(writtenData.getClass().isArray()) {
         writtenData = (T) Array.get(writtenData, 0);

--- a/integrations/apache-edgent/src/test/java/org/apache/plc4x/edgent/mock/MockConnection.java
+++ b/integrations/apache-edgent/src/test/java/org/apache/plc4x/edgent/mock/MockConnection.java
@@ -83,7 +83,6 @@ public class MockConnection extends AbstractPlcConnection implements PlcReader, 
       return new MockAddress(addressString);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public CompletableFuture<PlcReadResponse> read(PlcReadRequest readRequest) {
       curReadCnt++;

--- a/integrations/apache-mynewt/pom.xml
+++ b/integrations/apache-mynewt/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>apache-mynewt</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Integrations: Apache Mynewt</name>

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>integrations</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Integrations</name>

--- a/plc4c/pom.xml
+++ b/plc4c/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4c</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PLC4C</name>

--- a/plc4j/api/pom.xml
+++ b/plc4j/api/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plc4j-api</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>PLC4J: API</name>
   <description>Central API Module.</description>
 

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcConnectionException.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcConnectionException.java
@@ -19,6 +19,7 @@ under the License.
 package org.apache.plc4x.java.api.exceptions;
 
 public class PlcConnectionException extends PlcException {
+    private static final long serialVersionUID = 1L;
 
     public PlcConnectionException(String message) {
         super(message);

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcException.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcException.java
@@ -23,6 +23,7 @@ package org.apache.plc4x.java.api.exceptions;
  * PlcException.
  */
 public class PlcException extends Exception {
+    private static final long serialVersionUID = 1L;
 
     public PlcException(String message) {
         super(message);

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcIoException.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcIoException.java
@@ -22,6 +22,7 @@ package org.apache.plc4x.java.api.exceptions;
  * Base exception for all IO related exceptions.
  */
 public class PlcIoException extends PlcException {
+    private static final long serialVersionUID = 1L;
 
     public PlcIoException(String message) {
         super(message);

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcProtocolException.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/exceptions/PlcProtocolException.java
@@ -24,6 +24,7 @@ package org.apache.plc4x.java.api.exceptions;
  * any other problems occur which are related to the protocol being implemented.
  */
 public class PlcProtocolException extends PlcException {
+    private static final long serialVersionUID = 1L;
 
     public PlcProtocolException(String message) {
         super(message);

--- a/plc4j/core/pom.xml
+++ b/plc4j/core/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plc4j-core</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>PLC4J: Core</name>
   <description>Implementation of the core PLC4J system containing the DriverManger.</description>
 

--- a/plc4j/pom.xml
+++ b/plc4j/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PLC4J</name>

--- a/plc4j/protocols/pom.xml
+++ b/plc4j/protocols/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j-protocols</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PLC4J: Protocols</name>

--- a/plc4j/protocols/s7-utils/pom.xml
+++ b/plc4j/protocols/s7-utils/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plc4j-protocol-s7-utils</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>PLC4J: Protocol: S7-Utils</name>
   <description>Some utils used for helping to document the format.</description>
 

--- a/plc4j/protocols/s7/pom.xml
+++ b/plc4j/protocols/s7/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plc4j-protocol-s7</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>PLC4J: Protocol: S7</name>
   <description>Implementation of a PLC4X driver able to speak with S7 devices using the S7 protocol.</description>
 

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/isotp/netty/IsoTPProtocolTest.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/isotp/netty/IsoTPProtocolTest.java
@@ -18,25 +18,40 @@ under the License.
 */
 package org.apache.plc4x.java.isotp.netty;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.channel.ChannelHandlerContext;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
 import org.apache.plc4x.java.isoontcp.netty.model.IsoOnTcpMessage;
 import org.apache.plc4x.java.isotp.netty.model.IsoTPMessage;
-import org.apache.plc4x.java.isotp.netty.model.params.*;
-import org.apache.plc4x.java.isotp.netty.model.tpdus.*;
-import org.apache.plc4x.java.isotp.netty.model.types.*;
-import org.apache.plc4x.java.netty.NettyTestBase;
+import org.apache.plc4x.java.isotp.netty.model.params.CalledTsapParameter;
+import org.apache.plc4x.java.isotp.netty.model.params.CallingTsapParameter;
+import org.apache.plc4x.java.isotp.netty.model.params.ChecksumParameter;
+import org.apache.plc4x.java.isotp.netty.model.params.DisconnectAdditionalInformationParameter;
+import org.apache.plc4x.java.isotp.netty.model.params.Parameter;
+import org.apache.plc4x.java.isotp.netty.model.params.TpduSizeParameter;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.ConnectionConfirmTpdu;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.ConnectionRequestTpdu;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.DataTpdu;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.DisconnectConfirmTpdu;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.DisconnectRequestTpdu;
+import org.apache.plc4x.java.isotp.netty.model.tpdus.ErrorTpdu;
+import org.apache.plc4x.java.isotp.netty.model.types.DeviceGroup;
+import org.apache.plc4x.java.isotp.netty.model.types.DisconnectReason;
+import org.apache.plc4x.java.isotp.netty.model.types.ParameterCode;
+import org.apache.plc4x.java.isotp.netty.model.types.ProtocolClass;
+import org.apache.plc4x.java.isotp.netty.model.types.RejectCause;
+import org.apache.plc4x.java.isotp.netty.model.types.TpduCode;
+import org.apache.plc4x.java.isotp.netty.model.types.TpduSize;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
 
 public class IsoTPProtocolTest {
 

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/S7PlcTestConsole.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/S7PlcTestConsole.java
@@ -18,6 +18,10 @@ under the License.
 */
 package org.apache.plc4x.java.s7;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+
 import org.apache.plc4x.java.PlcDriverManager;
 import org.apache.plc4x.java.api.connection.PlcConnection;
 import org.apache.plc4x.java.api.connection.PlcReader;
@@ -26,10 +30,6 @@ import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.model.Address;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
 
 public class S7PlcTestConsole {
 
@@ -52,17 +52,18 @@ public class S7PlcTestConsole {
             if (reader.isPresent()) {
                 PlcReader plcReader = reader.get();
 
-                Scanner scanner = new Scanner(System.in);
-                String line;
-                while(!"exit".equalsIgnoreCase(line = scanner.next())) {
-                    try {
-                        Address address = plcConnection.parseAddress(line);
-                        PlcReadResponse plcReadResponse = plcReader.read(new PlcReadRequest(Byte.class, address)).get();
-                        List<Object> data = plcReadResponse.getResponseItems().get(0).getValues();
-                        System.out.println("Response: " + data.get(0));
-                    } catch(Exception e) {
-                        e.printStackTrace();
-                    }
+                try (Scanner scanner = new Scanner(System.in)) {
+                  String line;
+                  while(!"exit".equalsIgnoreCase(line = scanner.next())) {
+                      try {
+                          Address address = plcConnection.parseAddress(line);
+                          PlcReadResponse plcReadResponse = plcReader.read(new PlcReadRequest(Byte.class, address)).get();
+                          List<Object> data = plcReadResponse.getResponseItems().get(0).getValues();
+                          System.out.println("Response: " + data.get(0));
+                      } catch(Exception e) {
+                          e.printStackTrace();
+                      }
+                  }
                 }
             }
         }

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/netty/model/types/S7TypeTests.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/netty/model/types/S7TypeTests.java
@@ -19,10 +19,10 @@ under the License.
 
 package org.apache.plc4x.java.s7.netty.model.types;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class S7TypeTests {
 
@@ -123,7 +123,7 @@ class S7TypeTests {
     void memoryAccess() {
         MemoryArea memoryArea = MemoryArea.DATA_BLOCKS;
 
-        assertTrue(memoryArea.valueOf((byte)0x84) == MemoryArea.DATA_BLOCKS, "0x84 incorrectly mapped");
+        assertTrue(MemoryArea.valueOf((byte)0x84) == MemoryArea.DATA_BLOCKS, "0x84 incorrectly mapped");
         assertTrue(memoryArea.getCode() == (byte)0x84, "code is not 0x84");
     }
 
@@ -132,6 +132,6 @@ class S7TypeTests {
     void unknownMemoryAccess() {
         MemoryArea memoryArea = MemoryArea.DATA_BLOCKS;
 
-        assertTrue(memoryArea.valueOf((byte)0xFF) == null, "Unexpected value mapped");
+        assertTrue(MemoryArea.valueOf((byte)0xFF) == null, "Unexpected value mapped");
      }
 }

--- a/plc4j/protocols/utils/pom.xml
+++ b/plc4j/protocols/utils/pom.xml
@@ -29,8 +29,6 @@
   </parent>
 
   <artifactId>plc4j-protocol-utils</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-
   <name>PLC4J: Protocol: Utils</name>
   <description>Some little helpers that support development of protocol modules.</description>
 

--- a/plc4s/pom.xml
+++ b/plc4s/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4s</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PLC4S</name>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-scm-publish-plugin</artifactId>
-        <version>1.1</version>
         <configuration>
           <!-- mono-module doesn't require site:stage -->
           <content>${project.build.directory}/staging</content>

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,36 @@
           <artifactId>maven-changelog-plugin</artifactId>
           <version>2.3</version>
         </plugin>
+        
+        <!--                                                                                                                                                                  
+              This is a fake plugin which is used to tell m2e (Eclipse) how                                                                                                   
+              to process this maven project.                                                                                                                                  
+        -->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-remote-resources-plugin</artifactId>
+                    <versionRange>[1.0.0,)</versionRange>
+                    <goals>
+                      <goal>process</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+        
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Cleanup a number of warnings reported by Eclipse.  
There are still 50+ warnings related to raw types, casts, type safety as well as unused field/local-variables.

Please comment if you have concerns with any of these changes.