### PR TITLE
cleanup some warnings (in Eclipse)

### DIFF
--- a/examples/dummy-driver/src/main/java/org/apache/plc4x/java/examples/dummydriver/connection/DummyConnection.java
+++ b/examples/dummy-driver/src/main/java/org/apache/plc4x/java/examples/dummydriver/connection/DummyConnection.java
@@ -18,13 +18,18 @@ under the License.
 */
 package org.apache.plc4x.java.examples.dummydriver.connection;
 
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.plc4x.java.api.connection.AbstractPlcConnection;
 import org.apache.plc4x.java.api.connection.PlcReader;
 import org.apache.plc4x.java.api.connection.PlcWriter;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
-import org.apache.plc4x.java.api.messages.*;
+import org.apache.plc4x.java.api.messages.PlcReadRequest;
+import org.apache.plc4x.java.api.messages.PlcReadResponse;
+import org.apache.plc4x.java.api.messages.PlcRequestContainer;
+import org.apache.plc4x.java.api.messages.PlcWriteRequest;
+import org.apache.plc4x.java.api.messages.PlcWriteResponse;
 import org.apache.plc4x.java.api.model.Address;
 import org.apache.plc4x.java.examples.dummydriver.model.DummyAddress;
 import org.apache.plc4x.java.examples.dummydriver.netty.DummyProtocol;
@@ -33,17 +38,24 @@ import org.apache.plc4x.java.utils.rawsockets.netty.RawSocketChannel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
 
 public class DummyConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
 
+    @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(DummyConnection.class);
 
     private final String hostName;
 
     private EventLoopGroup workerGroup;
     private Channel channel;
+    @SuppressWarnings("unused")
     private boolean connected;
 
     public DummyConnection(String hostName) {
@@ -71,7 +83,7 @@ public class DummyConnection extends AbstractPlcConnection implements PlcReader,
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(workerGroup);
             bootstrap.channel(RawSocketChannel.class);
-            bootstrap.handler(new ChannelInitializer() {
+            bootstrap.handler(new ChannelInitializer<Channel>() {
                 @Override
                 protected void initChannel(Channel channel) throws Exception {
                     ChannelPipeline pipeline = channel.pipeline();

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/PlcRequest.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/PlcRequest.java
@@ -18,15 +18,16 @@ under the License.
 */
 package org.apache.plc4x.java.api.messages;
 
-import org.apache.plc4x.java.api.messages.items.RequestItem;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.plc4x.java.api.messages.items.RequestItem;
+
 /**
  * Base type for all messages sent from the plc4x system to a connected plc.
+ * @param <REQUEST_ITEM> 
  */
 public abstract class PlcRequest<REQUEST_ITEM extends RequestItem> implements PlcMessage {
 

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/PlcResponse.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/PlcResponse.java
@@ -18,16 +18,19 @@ under the License.
 */
 package org.apache.plc4x.java.api.messages;
 
-import org.apache.plc4x.java.api.messages.items.RequestItem;
-import org.apache.plc4x.java.api.messages.items.ResponseItem;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.plc4x.java.api.messages.items.RequestItem;
+import org.apache.plc4x.java.api.messages.items.ResponseItem;
+
 /**
  * Base type for all response messages sent as response for a prior request
  * from a plc to the plc4x system.
+ * @param <REQUEST> 
+ * @param <RESPONSE_ITEM> 
+ * @param <REQUEST_ITEM> 
  */
 public abstract class PlcResponse<REQUEST extends PlcRequest, RESPONSE_ITEM extends ResponseItem, REQUEST_ITEM extends RequestItem> implements PlcMessage {
 

--- a/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/specific/TypeSafePlcWriteResponse.java
+++ b/plc4j/api/src/main/java/org/apache/plc4x/java/api/messages/specific/TypeSafePlcWriteResponse.java
@@ -18,11 +18,11 @@ under the License.
 */
 package org.apache.plc4x.java.api.messages.specific;
 
-import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.api.messages.items.WriteResponseItem;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.plc4x.java.api.messages.PlcWriteResponse;
+import org.apache.plc4x.java.api.messages.items.WriteResponseItem;
 
 public class TypeSafePlcWriteResponse<T> extends PlcWriteResponse {
 
@@ -30,7 +30,6 @@ public class TypeSafePlcWriteResponse<T> extends PlcWriteResponse {
         super(request, responseItem);
     }
 
-    @SuppressWarnings("unchecked")
     public TypeSafePlcWriteResponse(TypeSafePlcWriteRequest<T> request, List<WriteResponseItem<T>> responseItems) {
         super(request, responseItems);
     }

--- a/plc4j/protocols/ads/pom.xml
+++ b/plc4j/protocols/ads/pom.xml
@@ -82,7 +82,6 @@
     <dependency>
       <groupId>org.pcap4j</groupId>
       <artifactId>pcap4j-core</artifactId>
-      <version>1.7.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/S7PlcTestConsole.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/S7PlcTestConsole.java
@@ -18,6 +18,10 @@ under the License.
 */
 package org.apache.plc4x.java.s7;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+
 import org.apache.plc4x.java.PlcDriverManager;
 import org.apache.plc4x.java.api.connection.PlcConnection;
 import org.apache.plc4x.java.api.connection.PlcReader;
@@ -26,10 +30,6 @@ import org.apache.plc4x.java.api.messages.specific.TypeSafePlcReadResponse;
 import org.apache.plc4x.java.api.model.Address;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
 
 public class S7PlcTestConsole {
 
@@ -66,6 +66,7 @@ public class S7PlcTestConsole {
                         e.printStackTrace();
                     }
                 }
+                scanner.close();
             }
         }
         // Catch any exception or the application won't be able to finish if something goes wrong.

--- a/plc4j/utils/pom.xml
+++ b/plc4j/utils/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j-utils</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PLC4J: Utils</name>

--- a/plc4j/utils/raw-sockets/pom.xml
+++ b/plc4j/utils/raw-sockets/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j-utils-raw-sockets</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
 
   <name>PLC4J: Utils: Raw-Sockets</name>
   <description>An implementation of a Netty Channel that allows implementing protocols below the TCP and UCP level.</description>

--- a/plc4j/utils/raw-sockets/src/main/java/org/apache/plc4x/java/utils/rawsockets/RawSocketException.java
+++ b/plc4j/utils/raw-sockets/src/main/java/org/apache/plc4x/java/utils/rawsockets/RawSocketException.java
@@ -17,6 +17,8 @@ package org.apache.plc4x.java.utils.rawsockets;
 
 public class RawSocketException extends Exception {
 
+    private static final long serialVersionUID = 1L;
+
     public RawSocketException() {
         super();
     }

--- a/plc4j/utils/raw-sockets/src/main/java/org/apache/plc4x/java/utils/rawsockets/netty/RawSocketAddress.java
+++ b/plc4j/utils/raw-sockets/src/main/java/org/apache/plc4x/java/utils/rawsockets/netty/RawSocketAddress.java
@@ -21,7 +21,8 @@ package org.apache.plc4x.java.utils.rawsockets.netty;
 import java.net.SocketAddress;
 
 public class RawSocketAddress extends SocketAddress {
-
+    private static final long serialVersionUID = 1L;
+    
     private String hostName;
 
     public RawSocketAddress(String hostName) {

--- a/plc4j/utils/test-utils/pom.xml
+++ b/plc4j/utils/test-utils/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j-utils-test-utils</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
 
   <name>PLC4J: Utils: Test Utils</name>
   <description>A set of test utils. Especially defining the test-categories used to categorize tests.</description>

--- a/plc4j/utils/wireshark-utils/pom.xml
+++ b/plc4j/utils/wireshark-utils/pom.xml
@@ -29,7 +29,6 @@
   </parent>
 
   <artifactId>plc4j-utils-wireshark-utils</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
 
   <name>PLC4J: Utils: WireShark Utils</name>
   <description>A set of helper utilities that allow reading and writing of `pcapng` files so they can be inspected with WireShark.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.0-M1</version> <!--$NO-MVN-MAN-VER$-->
         <inherited>false</inherited>
         <executions>
           <execution>


### PR DESCRIPTION
- remove pom: Version is duplicate of parent version
- suppress pom: Overriding version for maven-enforcer-plugin
- remove pom: Duplicating managed version for pcap4j-core
- remove some unnecessary @SuppressWarnings
- add missing serialVersionUID
- suppress some unused variable warnings
- add some missing javadoc tags
- fix Resource leak: 'scanner' is never closed