### PR TITLE
Fixed NPE in S7PlcConnection#close.

### DIFF
--- a/plc4j/protocols/s7/pom.xml
+++ b/plc4j/protocols/s7/pom.xml
@@ -101,6 +101,10 @@
       <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/plc4j/protocols/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
+++ b/plc4j/protocols/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
@@ -175,6 +175,17 @@ public class S7PlcConnection extends AbstractPlcConnection implements PlcReader,
         return paramMaxAmqCallee;
     }
 
+    /**
+     * Closes the S7 connection.
+     * First, a disconnect request is send to the PLC and after that, the Session and the channel are closed and
+     * invalidated.
+     *
+     * Then {@link ChannelFuture#await()} is used to see if the PLC closes the connection as expected.
+     * We have to use {@link ChannelFuture#await()} here for two reasons.
+     * First, netty does not allow blocking calls inside {@link io.netty.util.concurrent.GenericFutureListener}.
+     * Second, a timeout ensures that the close operation will abort in case of, e.g., transportation problems and the
+     * jvm can shut down gracefully.
+     */
     @Override
     public void close() {
         if ((channel != null) && channel.isOpen()) {
@@ -183,14 +194,19 @@ public class S7PlcConnection extends AbstractPlcConnection implements PlcReader,
                 (short) 0x0000, (short) 0x000F, DisconnectReason.NORMAL, Collections.emptyList(),
                 null);
             ChannelFuture sendDisconnectRequestFuture = channel.writeAndFlush(disconnectRequest);
-            sendDisconnectRequestFuture.addListener((ChannelFutureListener) future -> {
-                // Close the session itself.
-                channel.closeFuture().await();
+            // Wait if the PLC closes the connection
+            try {
+                // TODO 02.08.18 jf: Do we have global constants for things like timeouts?
+                channel.closeFuture().await(1_000);
+            } catch (InterruptedException e) {
+                logger.warn("Connection was not closed by PLC, has to be closed from driver side now.", e);
+            } finally {
+                // close the session itself.
                 channel.eventLoop().parent().shutdownGracefully();
-            });
-            sendDisconnectRequestFuture.awaitUninterruptibly();
+                super.close();
+            }
         }
-        super.close();
+
     }
 
 

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/connection/S7PlcConnectionIT.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/connection/S7PlcConnectionIT.java
@@ -58,7 +58,12 @@ public class S7PlcConnectionIT {
     @After
     public void tearDown() {
         if(s7PlcConnection.isConnected()) {
-            s7PlcConnection.close();
+            try {
+                s7PlcConnection.close();
+            } catch (NullPointerException e) {
+                // NPE is possibly thrown due to setup in S7PlcTestConnection (Embedded Channel)
+                logger.warn("Received NPE on close, e");
+            }
         }
         s7PlcConnection = null;
         channel = null;

--- a/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/connection/S7PlcConnectionIT.java
+++ b/plc4j/protocols/s7/src/test/java/org/apache/plc4x/java/s7/connection/S7PlcConnectionIT.java
@@ -58,12 +58,7 @@ public class S7PlcConnectionIT {
     @After
     public void tearDown() {
         if(s7PlcConnection.isConnected()) {
-            try {
-                s7PlcConnection.close();
-            } catch (NullPointerException e) {
-                // NPE is possibly thrown due to setup in S7PlcTestConnection (Embedded Channel)
-                logger.warn("Received NPE on close, e");
-            }
+            s7PlcConnection.close();
         }
         s7PlcConnection = null;
         channel = null;


### PR DESCRIPTION
Fix for the NPE in S7PlcConnection's close method.
After fixing the NPE there was a netty blockingException, thus I had to refactor the program logic a bit.
Please check if this is suitable the way I dit this (I tried to add enough comment to make it understandable).