### PR TITLE
Fefactor abstract connection class

### DIFF
--- a/examples/dummy-driver/src/main/java/org/apache/plc4x/java/examples/dummydriver/connection/DummyConnection.java
+++ b/examples/dummy-driver/src/main/java/org/apache/plc4x/java/examples/dummydriver/connection/DummyConnection.java
@@ -25,7 +25,7 @@ import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.TcpSocketChannelFactory;
 import org.apache.plc4x.java.base.messages.*;
 import org.slf4j.Logger;
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.net.InetAddress;
 import java.util.concurrent.CompletableFuture;
 
-public class DummyConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
+public class DummyConnection extends NettyPlcConnection implements PlcReader, PlcWriter {
 
     @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(DummyConnection.class);

--- a/plc4j/core/src/test/java/org/apache/plc4x/java/mock/MockConnection.java
+++ b/plc4j/core/src/test/java/org/apache/plc4x/java/mock/MockConnection.java
@@ -22,12 +22,12 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import org.apache.plc4x.java.api.authentication.PlcAuthentication;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.TestChannelFactory;
 
 import java.util.concurrent.CompletableFuture;
 
-public class MockConnection extends AbstractPlcConnection {
+public class MockConnection extends NettyPlcConnection {
 
     private final PlcAuthentication authentication;
 

--- a/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/connection/AdsAbstractPlcConnection.java
+++ b/plc4j/protocols/ads/src/main/java/org/apache/plc4x/java/ads/connection/AdsAbstractPlcConnection.java
@@ -34,7 +34,7 @@ import org.apache.plc4x.java.ads.model.SymbolicAdsField;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.exceptions.PlcRuntimeException;
 import org.apache.plc4x.java.api.messages.*;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.ChannelFactory;
 import org.apache.plc4x.java.base.messages.*;
 import org.slf4j.Logger;
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.*;
 
-public abstract class AdsAbstractPlcConnection extends AbstractPlcConnection implements PlcReader, PlcWriter, PlcProprietarySender {
+public abstract class AdsAbstractPlcConnection extends NettyPlcConnection implements PlcReader, PlcWriter, PlcProprietarySender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AdsAbstractPlcConnection.class);
 

--- a/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsConnectionFactoryTest.java
+++ b/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsConnectionFactoryTest.java
@@ -21,7 +21,7 @@ package org.apache.plc4x.java.ads.connection;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.plc4x.java.ads.api.generic.types.AmsNetId;
 import org.apache.plc4x.java.ads.api.generic.types.AmsPort;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.SerialChannelFactory;
 import org.apache.plc4x.java.base.connection.TcpSocketChannelFactory;
 import org.junit.Test;
@@ -117,7 +117,7 @@ public class AdsConnectionFactoryTest {
 
     public void assertPort(AdsTcpPlcConnection adsTcpPlcConnection, int port) throws Exception {
         TcpSocketChannelFactory channelFactory = (TcpSocketChannelFactory) FieldUtils
-            .getDeclaredField(AbstractPlcConnection.class, "channelFactory", true)
+            .getDeclaredField(NettyPlcConnection.class, "channelFactory", true)
             .get(adsTcpPlcConnection);
         assertEquals(port, channelFactory.getPort());
     }
@@ -157,7 +157,7 @@ public class AdsConnectionFactoryTest {
 
     public void assertPort(AdsSerialPlcConnection adsSerialPlcConnection, String serialPort) throws Exception {
         SerialChannelFactory channelFactory = (SerialChannelFactory) FieldUtils
-            .getDeclaredField(AbstractPlcConnection.class, "channelFactory", true)
+            .getDeclaredField(NettyPlcConnection.class, "channelFactory", true)
             .get(adsSerialPlcConnection);
         assertEquals(serialPort, channelFactory.getSerialPort());
     }

--- a/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsSerialPlcConnectionTest.java
+++ b/plc4j/protocols/ads/src/test/java/org/apache/plc4x/java/ads/connection/AdsSerialPlcConnectionTest.java
@@ -30,7 +30,7 @@ import org.apache.plc4x.java.ads.api.serial.AmsSerialFrame;
 import org.apache.plc4x.java.ads.api.serial.types.*;
 import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.SerialChannelFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -83,7 +83,7 @@ public class AdsSerialPlcConnectionTest {
     }
 
     private void prepareSerialSimulator() throws Exception {
-        Field channelFactoryField = FieldUtils.getField(AbstractPlcConnection.class, "channelFactory", true);
+        Field channelFactoryField = FieldUtils.getField(NettyPlcConnection.class, "channelFactory", true);
         SerialChannelFactory serialChannelFactory = (SerialChannelFactory) channelFactoryField.get(SUT);
         SerialChannelFactory serialChannelFactorySpied = spy(serialChannelFactory);
         EmbeddedChannel embeddedChannel = new EmbeddedChannel(SUT.getChannelHandler(null));

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
@@ -1,0 +1,77 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+*/
+package org.apache.plc4x.java.base.connection;
+
+import org.apache.plc4x.java.api.PlcConnection;
+import org.apache.plc4x.java.api.exceptions.PlcUnsupportedOperationException;
+import org.apache.plc4x.java.api.messages.PlcReadRequest;
+import org.apache.plc4x.java.api.messages.PlcSubscriptionRequest;
+import org.apache.plc4x.java.api.messages.PlcUnsubscriptionRequest;
+import org.apache.plc4x.java.api.messages.PlcWriteRequest;
+import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
+
+/**
+ * Base class for implementing connections.
+ * Per default, all operations (read, write, subscribe) are unsupported.
+ * Concrete implementations should override the methods indicating connection capabilities
+ * and for obtaining respective request builders.
+ */
+public abstract class AbstractPlcConnection implements PlcConnection, PlcConnectionMetadata {
+
+    @Override
+    public PlcConnectionMetadata getMetadata() {
+        return this;
+    }
+
+    @Override
+    public boolean canRead() {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite() {
+        return false;
+    }
+
+    @Override
+    public boolean canSubscribe() {
+        return false;
+    }
+
+    @Override
+    public PlcReadRequest.Builder readRequestBuilder() {
+        throw new PlcUnsupportedOperationException("The connection does not support reading");
+    }
+
+    @Override
+    public PlcWriteRequest.Builder writeRequestBuilder() {
+        throw new PlcUnsupportedOperationException("The connection does not support writing");
+    }
+
+    @Override
+    public PlcSubscriptionRequest.Builder subscriptionRequestBuilder() {
+        throw new PlcUnsupportedOperationException("The connection does not support subscription");
+    }
+
+    @Override
+    public PlcUnsubscriptionRequest.Builder unsubscriptionRequestBuilder() {
+        throw new PlcUnsupportedOperationException("The connection does not support subscription");
+    }
+
+}

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
@@ -36,7 +36,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-public abstract class AbstractPlcConnection implements PlcConnection, PlcConnectionMetadata {
+public abstract class NettyPlcConnection implements PlcConnection, PlcConnectionMetadata {
 
     /**
      * a {@link HashedWheelTimer} shall be only instantiated once.
@@ -52,11 +52,11 @@ public abstract class AbstractPlcConnection implements PlcConnection, PlcConnect
 
     protected boolean connected;
 
-    protected AbstractPlcConnection(ChannelFactory channelFactory) {
+    protected NettyPlcConnection(ChannelFactory channelFactory) {
         this(channelFactory, false);
     }
 
-    protected AbstractPlcConnection(ChannelFactory channelFactory, boolean awaitSessionSetupComplete) {
+    protected NettyPlcConnection(ChannelFactory channelFactory, boolean awaitSessionSetupComplete) {
         this.channelFactory = channelFactory;
         this.awaitSessionSetupComplete = awaitSessionSetupComplete;
         this.connected = false;

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
@@ -22,21 +22,14 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
-import org.apache.plc4x.java.api.PlcConnection;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.exceptions.PlcIoException;
-import org.apache.plc4x.java.api.exceptions.PlcUnsupportedOperationException;
-import org.apache.plc4x.java.api.messages.PlcReadRequest;
-import org.apache.plc4x.java.api.messages.PlcSubscriptionRequest;
-import org.apache.plc4x.java.api.messages.PlcUnsubscriptionRequest;
-import org.apache.plc4x.java.api.messages.PlcWriteRequest;
-import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-public abstract class NettyPlcConnection implements PlcConnection, PlcConnectionMetadata {
+public abstract class NettyPlcConnection extends AbstractPlcConnection {
 
     /**
      * a {@link HashedWheelTimer} shall be only instantiated once.
@@ -105,46 +98,6 @@ public abstract class NettyPlcConnection implements PlcConnection, PlcConnection
     @Override
     public boolean isConnected() {
         return connected;
-    }
-
-    @Override
-    public PlcConnectionMetadata getMetadata() {
-        return this;
-    }
-
-    @Override
-    public boolean canRead() {
-        return false;
-    }
-
-    @Override
-    public boolean canWrite() {
-        return false;
-    }
-
-    @Override
-    public boolean canSubscribe() {
-        return false;
-    }
-
-    @Override
-    public PlcReadRequest.Builder readRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support reading");
-    }
-
-    @Override
-    public PlcWriteRequest.Builder writeRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support writing");
-    }
-
-    @Override
-    public PlcSubscriptionRequest.Builder subscriptionRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support subscription");
-    }
-
-    @Override
-    public PlcUnsubscriptionRequest.Builder unsubscriptionRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support subscription");
     }
 
     public Channel getChannel() {

--- a/plc4j/protocols/driver-bases/test/src/main/java/org/apache/plc4x/java/base/connection/MockConnection.java
+++ b/plc4j/protocols/driver-bases/test/src/main/java/org/apache/plc4x/java/base/connection/MockConnection.java
@@ -22,7 +22,7 @@ import io.netty.channel.ChannelHandler;
 
 import java.util.concurrent.CompletableFuture;
 
-public class MockConnection extends AbstractPlcConnection {
+public class MockConnection extends NettyPlcConnection {
 
     public MockConnection() {
         super(new TestChannelFactory());

--- a/plc4j/protocols/ethernetip/src/main/java/org/apache/plc4x/java/ethernetip/connection/BaseEtherNetIpPlcConnection.java
+++ b/plc4j/protocols/ethernetip/src/main/java/org/apache/plc4x/java/ethernetip/connection/BaseEtherNetIpPlcConnection.java
@@ -23,7 +23,7 @@ import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.ChannelFactory;
 import org.apache.plc4x.java.base.messages.*;
 import org.apache.plc4x.java.ethernetip.netty.util.EnipPlcFieldHandler;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 
-public abstract class BaseEtherNetIpPlcConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
+public abstract class BaseEtherNetIpPlcConnection extends NettyPlcConnection implements PlcReader, PlcWriter {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseEtherNetIpPlcConnection.class);
 

--- a/plc4j/protocols/modbus/src/main/java/org/apache/plc4x/java/modbus/connection/BaseModbusPlcConnection.java
+++ b/plc4j/protocols/modbus/src/main/java/org/apache/plc4x/java/modbus/connection/BaseModbusPlcConnection.java
@@ -23,7 +23,7 @@ import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.ChannelFactory;
 import org.apache.plc4x.java.base.messages.*;
 import org.apache.plc4x.java.modbus.util.ModbusPlcFieldHandler;
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 
-public abstract class BaseModbusPlcConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
+public abstract class BaseModbusPlcConnection extends NettyPlcConnection implements PlcReader, PlcWriter {
 
     private static final Logger logger = LoggerFactory.getLogger(BaseModbusPlcConnection.class);
 

--- a/plc4j/protocols/modbus/src/test/java/org/apache/plc4x/java/modbus/connection/ModbusConnectionFactoryTest.java
+++ b/plc4j/protocols/modbus/src/test/java/org/apache/plc4x/java/modbus/connection/ModbusConnectionFactoryTest.java
@@ -19,7 +19,7 @@
 package org.apache.plc4x.java.modbus.connection;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.SerialChannelFactory;
 import org.apache.plc4x.java.base.connection.TcpSocketChannelFactory;
 import org.junit.Test;
@@ -70,7 +70,7 @@ public class ModbusConnectionFactoryTest {
 
     public void assertPort(ModbusTcpPlcConnection modbusTcpPlcConnection, int port) throws Exception {
         TcpSocketChannelFactory channelFactory = (TcpSocketChannelFactory) FieldUtils
-            .getDeclaredField(AbstractPlcConnection.class, "channelFactory", true)
+            .getDeclaredField(NettyPlcConnection.class, "channelFactory", true)
             .get(modbusTcpPlcConnection);
         assertEquals(port, channelFactory.getPort());
     }
@@ -88,7 +88,7 @@ public class ModbusConnectionFactoryTest {
 
     public void assertPort(ModbusSerialPlcConnection modbusSerialPlcConnection, String serialPort) throws Exception {
         SerialChannelFactory channelFactory = (SerialChannelFactory) FieldUtils
-            .getDeclaredField(AbstractPlcConnection.class, "channelFactory", true)
+            .getDeclaredField(NettyPlcConnection.class, "channelFactory", true)
             .get(modbusSerialPlcConnection);
         assertEquals(serialPort, channelFactory.getSerialPort());
     }

--- a/plc4j/protocols/modbus/src/test/java/org/apache/plc4x/java/modbus/connection/ModbusSerialPlcConnectionTest.java
+++ b/plc4j/protocols/modbus/src/test/java/org/apache/plc4x/java/modbus/connection/ModbusSerialPlcConnectionTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.SerialChannelFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -73,7 +73,7 @@ public class ModbusSerialPlcConnectionTest {
     }
 
     private void prepareSerialSimulator() throws Exception {
-        Field channelFactoryField = FieldUtils.getField(AbstractPlcConnection.class, "channelFactory", true);
+        Field channelFactoryField = FieldUtils.getField(NettyPlcConnection.class, "channelFactory", true);
         SerialChannelFactory serialChannelFactory = (SerialChannelFactory) channelFactoryField.get(SUT);
         SerialChannelFactory serialChannelFactorySpied = spy(serialChannelFactory);
         EmbeddedChannel embeddedChannel = new EmbeddedChannel(SUT.getChannelHandler(null));

--- a/plc4j/protocols/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
+++ b/plc4j/protocols/s7/src/main/java/org/apache/plc4x/java/s7/connection/S7PlcConnection.java
@@ -27,7 +27,7 @@ import org.apache.plc4x.java.api.messages.PlcReadRequest;
 import org.apache.plc4x.java.api.messages.PlcReadResponse;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteResponse;
-import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
+import org.apache.plc4x.java.base.connection.NettyPlcConnection;
 import org.apache.plc4x.java.base.connection.ChannelFactory;
 import org.apache.plc4x.java.base.connection.TcpSocketChannelFactory;
 import org.apache.plc4x.java.base.events.ConnectEvent;
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeoutException;
  * where the {bit-offset} is optional.
  * All Available Memory Areas for this mode are defined in the {@link MemoryArea} enum.
  */
-public class S7PlcConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
+public class S7PlcConnection extends NettyPlcConnection implements PlcReader, PlcWriter {
 
     private static final int ISO_ON_TCP_PORT = 102;
 

--- a/plc4j/protocols/src/site/asciidoc/developers/implementing-drivers.adoc
+++ b/plc4j/protocols/src/site/asciidoc/developers/implementing-drivers.adoc
@@ -198,7 +198,7 @@ If no form of `PlcAuthentication` is provided, the normal `connect` method is th
 If however authentication information is provided, the second connect method is used.
 However we still have to find and implement a protocol that actually supports authentication.
 
-The probably simplest way to implement a custom connection is to extend `org.apache.plc4x.java.base.connection.AbstractPlcConnection`.
+The probably simplest way to implement a custom connection is to extend `org.apache.plc4x.java.base.connection.NettyPlcConnection`.
 This allows passing in a `ChannelFactory` instance, which allows overriding the default communication channel used by the driver.
 
 An `AbstractPlcConnection` is required to implement a method called `getChannelHandler`.

--- a/plc4j/protocols/test/src/main/java/org/apache/plc4x/java/test/TestConnection.java
+++ b/plc4j/protocols/test/src/main/java/org/apache/plc4x/java/test/TestConnection.java
@@ -20,11 +20,12 @@ package org.apache.plc4x.java.test;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.plc4x.java.api.PlcConnection;
-import org.apache.plc4x.java.api.exceptions.PlcUnsupportedOperationException;
-import org.apache.plc4x.java.api.messages.*;
-import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
+import org.apache.plc4x.java.api.messages.PlcReadRequest;
+import org.apache.plc4x.java.api.messages.PlcReadResponse;
+import org.apache.plc4x.java.api.messages.PlcWriteRequest;
+import org.apache.plc4x.java.api.messages.PlcWriteResponse;
 import org.apache.plc4x.java.api.types.PlcResponseCode;
+import org.apache.plc4x.java.base.connection.AbstractPlcConnection;
 import org.apache.plc4x.java.base.messages.*;
 import org.apache.plc4x.java.base.messages.items.BaseDefaultFieldItem;
 
@@ -37,7 +38,7 @@ import java.util.concurrent.CompletableFuture;
  * Connection to a test device.
  * This class is not thread-safe.
  */
-class TestConnection implements PlcConnection, PlcConnectionMetadata, PlcReader, PlcWriter {
+class TestConnection extends AbstractPlcConnection implements PlcReader, PlcWriter {
     private final TestDevice device;
     private boolean connected = false;
 
@@ -61,11 +62,6 @@ class TestConnection implements PlcConnection, PlcConnectionMetadata, PlcReader,
     }
 
     @Override
-    public PlcConnectionMetadata getMetadata() {
-        return this;
-    }
-
-    @Override
     public boolean canRead() {
         return true;
     }
@@ -76,11 +72,6 @@ class TestConnection implements PlcConnection, PlcConnectionMetadata, PlcReader,
     }
 
     @Override
-    public boolean canSubscribe() {
-        return false;
-    }
-
-    @Override
     public PlcReadRequest.Builder readRequestBuilder() {
         return new DefaultPlcReadRequest.Builder(this, new TestFieldHandler());
     }
@@ -88,16 +79,6 @@ class TestConnection implements PlcConnection, PlcConnectionMetadata, PlcReader,
     @Override
     public PlcWriteRequest.Builder writeRequestBuilder() {
         return new DefaultPlcWriteRequest.Builder(this, new TestFieldHandler());
-    }
-
-    @Override
-    public PlcSubscriptionRequest.Builder subscriptionRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support subscription");
-    }
-
-    @Override
-    public PlcUnsubscriptionRequest.Builder unsubscriptionRequestBuilder() {
-        throw new PlcUnsupportedOperationException("The connection does not support subscription");
     }
 
     @Override


### PR DESCRIPTION
Moved dependency on *Netty* from `AbstractPlcConnection` to `NettyPlcConnection`. `AbstractPlcConnection` is now just a support class containing boilerplate for protocol implementors.