### PR TITLE
Feature/plc4 x 108 ping method

### DIFF
--- a/plc4j/drivers/simulated/src/main/java/org/apache/plc4x/java/simulated/connection/SimulatedPlcConnection.java
+++ b/plc4j/drivers/simulated/src/main/java/org/apache/plc4x/java/simulated/connection/SimulatedPlcConnection.java
@@ -29,6 +29,7 @@ import org.apache.plc4x.java.base.messages.*;
 import org.apache.plc4x.java.base.messages.items.BaseDefaultFieldItem;
 import org.apache.plc4x.java.base.model.*;
 
+import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -61,6 +62,12 @@ public class SimulatedPlcConnection extends AbstractPlcConnection implements Plc
     @Override
     public boolean isConnected() {
         return connected;
+    }
+
+    @Override
+    protected Optional<InetSocketAddress> getInetSocketAddress() {
+        // IS okay, isConnected is overridden
+        return Optional.empty();
     }
 
     @Override

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
@@ -83,13 +83,14 @@ public abstract class AbstractPlcConnection implements PlcConnection, PlcConnect
      * Otherwise it throws a {@link NotImplementedException} to inform the user about that.
      */
     protected boolean ping(int timeout) {
-        Optional<InetSocketAddress> address = getInetSocketAddress();
-        if (!address.isPresent()) {
-            throw new NotImplementedException("Tries to check the connection with ping, " +
-                "but no Socket Address is given!");
-        }
+        InetSocketAddress address = getInetSocketAddress()
+            .orElseThrow(() -> new NotImplementedException("Tries to check the connection with ping, " +
+                "but no Socket Address is given!"));
+
         try (Socket s = new Socket()) {
-            s.connect(address.get(), timeout);
+            s.connect(address, timeout);
+            // TODO keep the adress for a (timely) next request???
+            s.setReuseAddress(true);
             return true;
         } catch (Exception e) {
             LOGGER.debug("Unable to ping PLC", e);

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
@@ -18,6 +18,7 @@ under the License.
 */
 package org.apache.plc4x.java.base.connection;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.plc4x.java.api.PlcConnection;
 import org.apache.plc4x.java.api.exceptions.PlcUnsupportedOperationException;
 import org.apache.plc4x.java.api.messages.PlcReadRequest;
@@ -26,8 +27,13 @@ import org.apache.plc4x.java.api.messages.PlcUnsubscriptionRequest;
 import org.apache.plc4x.java.api.messages.PlcWriteRequest;
 import org.apache.plc4x.java.api.metadata.PlcConnectionMetadata;
 import org.apache.plc4x.java.base.messages.InternalPlcMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Base class for implementing connections.
@@ -36,6 +42,10 @@ import java.util.Objects;
  * and for obtaining respective request builders.
  */
 public abstract class AbstractPlcConnection implements PlcConnection, PlcConnectionMetadata {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPlcConnection.class);
+
+    private static final int PING_TIMEOUT_MS = 1_000;
 
     @Override
     public PlcConnectionMetadata getMetadata() {
@@ -56,6 +66,51 @@ public abstract class AbstractPlcConnection implements PlcConnection, PlcConnect
     public boolean canSubscribe() {
         return false;
     }
+
+    /**
+     * The default implementation uses the {@link #ping(int)} method.
+     * Drivers that want to implement a more specific version have to overide it.
+     */
+    @Override
+    public boolean isConnected() {
+        return ping(PING_TIMEOUT_MS);
+    }
+
+    /**
+     * Method that sends a test-request or ping to the PLC to check if the PLC is still there.
+     * In most cases this method should only be used from the {@link #isConnected()} method.
+     * This method can only be used if ghe {@link #getInetSocketAddress()} returns a Socket Adress.
+     * Otherwise it throws a {@link NotImplementedException} to inform the user about that.
+     */
+    protected boolean ping(int timeout) {
+        Optional<InetSocketAddress> address = getInetSocketAddress();
+        if (!address.isPresent()) {
+            throw new NotImplementedException("Tries to check the connection with ping, " +
+                "but no Socket Address is given!");
+        }
+        Socket s = null;
+        try {
+            s = new Socket();
+            s.connect(address.get(), timeout);
+            return true;
+        } catch (Exception e) {
+            LOGGER.debug("Unable to ping PLC", e);
+            return false;
+        } finally {
+            if (s != null) {
+                try {
+                    s.close();
+                } catch (Exception e) {
+                }
+            }
+        }
+    }
+
+    /**
+     * Strategy Pattern method for the {@link #ping(int)} method.
+     * If a driver has no Inet Socket adress, it has to return an Empty Optional, never null.
+     */
+    protected abstract Optional<InetSocketAddress> getInetSocketAddress();
 
     @Override
     public PlcReadRequest.Builder readRequestBuilder() {

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/AbstractPlcConnection.java
@@ -88,21 +88,12 @@ public abstract class AbstractPlcConnection implements PlcConnection, PlcConnect
             throw new NotImplementedException("Tries to check the connection with ping, " +
                 "but no Socket Address is given!");
         }
-        Socket s = null;
-        try {
-            s = new Socket();
+        try (Socket s = new Socket()) {
             s.connect(address.get(), timeout);
             return true;
         } catch (Exception e) {
             LOGGER.debug("Unable to ping PLC", e);
             return false;
-        } finally {
-            if (s != null) {
-                try {
-                    s.close();
-                } catch (Exception e) {
-                }
-            }
         }
     }
 

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/ChannelFactory.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/ChannelFactory.java
@@ -22,9 +22,17 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 public interface ChannelFactory {
 
     Channel createChannel(ChannelHandler channelHandler)
         throws PlcConnectionException;
+
+    /**
+     * If this Channel Facotry creates a Channel which has an ip / port it should return this
+     */
+    Optional<InetSocketAddress> getInetSocketAddress();
 
 }

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
@@ -25,6 +25,8 @@ import io.netty.util.Timer;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.api.exceptions.PlcIoException;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -94,9 +96,16 @@ public abstract class NettyPlcConnection extends AbstractPlcConnection {
         connected = false;
     }
 
+    /**
     @Override
     public boolean isConnected() {
         return connected && channel.isActive();
+    }
+     */
+
+    @Override
+    protected Optional<InetSocketAddress> getInetSocketAddress() {
+        return this.channelFactory.getInetSocketAddress();
     }
 
     public Channel getChannel() {

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
@@ -97,11 +97,18 @@ public abstract class NettyPlcConnection extends AbstractPlcConnection {
     }
 
     /**
+     * If a InetSocketAdress is present, it uses the "ping" based default.
+     * Otherwise does the "old" approach to check nettys channel (e.g. serial).
+     */
     @Override
     public boolean isConnected() {
-        return connected && channel.isActive();
+        // Use the "netty default" if no socket adress is present (like serial)
+        if (!getInetSocketAddress().isPresent()) {
+            return connected && channel.isActive();
+        } else {
+            return super.isConnected();
+        }
     }
-     */
 
     @Override
     protected Optional<InetSocketAddress> getInetSocketAddress() {

--- a/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
+++ b/plc4j/protocols/driver-bases/base/src/main/java/org/apache/plc4x/java/base/connection/NettyPlcConnection.java
@@ -106,6 +106,7 @@ public abstract class NettyPlcConnection extends AbstractPlcConnection {
         if (!getInetSocketAddress().isPresent()) {
             return connected && channel.isActive();
         } else {
+            // TODO sr: Should we add a check like previously, if the channel is active?
             return super.isConnected();
         }
     }

--- a/plc4j/protocols/driver-bases/base/src/test/java/org/apache/plc4x/java/base/connection/AbstractPlcConnectionTest.java
+++ b/plc4j/protocols/driver-bases/base/src/test/java/org/apache/plc4x/java/base/connection/AbstractPlcConnectionTest.java
@@ -26,6 +26,9 @@ import org.apache.plc4x.java.base.messages.PlcReader;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -40,6 +43,11 @@ class AbstractPlcConnectionTest implements WithAssertions {
         @Override
         public boolean isConnected() {
             throw new NotImplementedException("not used");
+        }
+
+        @Override
+        protected Optional<InetSocketAddress> getInetSocketAddress() {
+            return Optional.empty();
         }
 
         @Override

--- a/plc4j/protocols/driver-bases/base/src/test/java/org/apache/plc4x/java/base/connection/NettyPlcConnectionTest.java
+++ b/plc4j/protocols/driver-bases/base/src/test/java/org/apache/plc4x/java/base/connection/NettyPlcConnectionTest.java
@@ -23,16 +23,31 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 import org.apache.plc4x.java.base.events.ConnectEvent;
 import org.assertj.core.api.WithAssertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 
 public class NettyPlcConnectionTest implements WithAssertions {
 
-    NettyPlcConnection SUT = new NettyPlcConnection(EmbeddedChannel::new, true) {
+    private final ChannelFactory channelFactory = new ChannelFactory() {
+        @Override
+        public Channel createChannel(ChannelHandler channelHandler) throws PlcConnectionException {
+            return new EmbeddedChannel();
+        }
+
+        @Override
+        public Optional<InetSocketAddress> getInetSocketAddress() {
+            return Optional.empty();
+        }
+    };
+
+    NettyPlcConnection SUT = new NettyPlcConnection(channelFactory, true) {
         @Override
         protected ChannelHandler getChannelHandler(CompletableFuture<Void> sessionSetupCompleteFuture) {
             sessionSetupCompleteFuture.complete(null);

--- a/plc4j/protocols/driver-bases/raw-socket/src/main/java/org/apache/plc4x/java/base/connection/RawSocketChannelFactory.java
+++ b/plc4j/protocols/driver-bases/raw-socket/src/main/java/org/apache/plc4x/java/base/connection/RawSocketChannelFactory.java
@@ -23,6 +23,8 @@ import io.netty.channel.ChannelHandler;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Optional;
 
 public class RawSocketChannelFactory implements ChannelFactory {
 
@@ -34,6 +36,11 @@ public class RawSocketChannelFactory implements ChannelFactory {
         this.address = address;
         this.port = port;
         this.protocolId = protocolId;
+    }
+
+    @Override
+    public Optional<InetSocketAddress> getInetSocketAddress() {
+        return Optional.of(new InetSocketAddress(address, port));
     }
 
     @Override

--- a/plc4j/protocols/driver-bases/serial/src/main/java/org/apache/plc4x/java/base/connection/SerialChannelFactory.java
+++ b/plc4j/protocols/driver-bases/serial/src/main/java/org/apache/plc4x/java/base/connection/SerialChannelFactory.java
@@ -28,12 +28,20 @@ import io.netty.channel.jsc.JSerialCommDeviceAddress;
 import io.netty.channel.oio.OioEventLoopGroup;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 public class SerialChannelFactory implements ChannelFactory {
 
     private final String serialPort;
 
     public SerialChannelFactory(String serialPort) {
         this.serialPort = serialPort;
+    }
+
+    @Override
+    public Optional<InetSocketAddress> getInetSocketAddress() {
+        return Optional.empty();
     }
 
     @Override

--- a/plc4j/protocols/driver-bases/tcp/src/main/java/org/apache/plc4x/java/base/connection/TcpSocketChannelFactory.java
+++ b/plc4j/protocols/driver-bases/tcp/src/main/java/org/apache/plc4x/java/base/connection/TcpSocketChannelFactory.java
@@ -28,6 +28,8 @@ import io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.plc4x.java.api.exceptions.PlcConnectionException;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Optional;
 
 public class TcpSocketChannelFactory implements ChannelFactory {
 
@@ -68,5 +70,10 @@ public class TcpSocketChannelFactory implements ChannelFactory {
 
     public int getPort() {
         return port;
+    }
+
+    @Override
+    public Optional<InetSocketAddress> getInetSocketAddress() {
+        return Optional.of(new InetSocketAddress(address, port));
     }
 }

--- a/plc4j/protocols/driver-bases/test/src/main/java/org/apache/plc4x/java/base/connection/TestChannelFactory.java
+++ b/plc4j/protocols/driver-bases/test/src/main/java/org/apache/plc4x/java/base/connection/TestChannelFactory.java
@@ -22,6 +22,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.embedded.EmbeddedChannel;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 public class TestChannelFactory implements ChannelFactory {
 
     private EmbeddedChannel channel;
@@ -36,4 +39,8 @@ public class TestChannelFactory implements ChannelFactory {
         return channel;
     }
 
+    @Override
+    public Optional<InetSocketAddress> getInetSocketAddress() {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
I implemented a ping() method based on Gunters code (in fact it is Gunters code) and "redirected" the isConnected method there. 
I extended the NettyPlcConnection and the ConnectionFactory to use the ping based approach *if and only if* the protocol has ip adress and port.
But for all these, it should work out of the box now.

A manual test was performed by @timbo2k and me with S7 and Modbus-TCP and both worked excellent.